### PR TITLE
[Agent 7] feat: duplicate-safe connection management

### DIFF
--- a/docs/SMART_ROUTING/TODO_BOARD.md
+++ b/docs/SMART_ROUTING/TODO_BOARD.md
@@ -35,6 +35,15 @@
 
 ## 📅 Daily Standups
 
+### 2025-11-03 - Daily Standup
+
+#### Agent 7 - Connection Manager
+- **Yesterday:** N/A (Starting today)
+- **Today:** Reading docs, setting up branch, starting duplicate prevention implementation
+- **Tomorrow:** Integrating duplicate checks with ConnectionManager API
+- **Blockers:** None
+- **PRs:** None yet
+
 ### 2025-01-03 - Kickoff Day
 
 #### Agent 1 - Graph & Pathfinding

--- a/src/routing/core/ConnectionManager.ts
+++ b/src/routing/core/ConnectionManager.ts
@@ -10,6 +10,8 @@ import {
   RouteType,
 } from './types';
 
+const DEFAULT_DUPLICATE_TOLERANCE = 0.01; // 1 cm tolerance
+
 /**
  * ConnectionManager manages all connection points in the scene
  * and maintains the graph of connections between them.
@@ -37,6 +39,22 @@ export class ConnectionManager {
    * Add a connection point to the manager
    */
   addConnectionPoint(config: ConnectionPointConfig): ConnectionPoint {
+    const duplicateId = this.findDuplicateAt(
+      config.position,
+      config.type,
+      DEFAULT_DUPLICATE_TOLERANCE
+    );
+
+    if (duplicateId) {
+      const existingPoint = this.connectionPoints.get(duplicateId);
+      if (existingPoint) {
+        console.warn(
+          `Connection point already exists at this location (ID: ${duplicateId}). Returning existing point.`
+        );
+        return existingPoint;
+      }
+    }
+
     const point = new ConnectionPoint(config);
     this.connectionPoints.set(point.getId(), point);
     this.connections.set(point.getId(), []);
@@ -240,6 +258,36 @@ export class ConnectionManager {
    */
   getConnectionPointsByType(type: RouteType): ConnectionPoint[] {
     return Array.from(this.connectionPoints.values()).filter((p) => p.getType() === type);
+  }
+
+  /**
+   * Find an existing connection point at the provided position and type within a tolerance
+   */
+  findDuplicateAt(
+    position: Vector3,
+    type: RouteType,
+    tolerance = DEFAULT_DUPLICATE_TOLERANCE
+  ): string | null {
+    const safeTolerance = tolerance < 0 ? DEFAULT_DUPLICATE_TOLERANCE : tolerance;
+    const toleranceSquared = safeTolerance * safeTolerance;
+
+    for (const point of this.connectionPoints.values()) {
+      if (point.getType() !== type) {
+        continue;
+      }
+
+      const existingPosition = point.getPosition();
+      const dx = existingPosition.x - position.x;
+      const dy = existingPosition.y - position.y;
+      const dz = existingPosition.z - position.z;
+      const distanceSquared = dx * dx + dy * dy + dz * dz;
+
+      if (distanceSquared <= toleranceSquared) {
+        return point.getId();
+      }
+    }
+
+    return null;
   }
 
   /**

--- a/tests/routing/Agent7-Connections.test.ts
+++ b/tests/routing/Agent7-Connections.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { ConnectionManager } from '../../src/routing/core/ConnectionManager';
+import { ConnectionPointConfig } from '../../src/routing/core/types';
+
+const baseConfig: ConnectionPointConfig = {
+  type: 'pipe',
+  position: { x: 0, y: 0, z: 0 },
+  direction: { x: 0, y: 0, z: 1 },
+  specifications: { size: '1in' },
+};
+
+function createConfig(overrides: Partial<ConnectionPointConfig> = {}): ConnectionPointConfig {
+  return {
+    ...baseConfig,
+    position: overrides.position ?? { ...baseConfig.position },
+    direction: overrides.direction ?? { ...baseConfig.direction },
+    specifications: overrides.specifications ?? { ...baseConfig.specifications },
+    type: overrides.type ?? baseConfig.type,
+    parentObject: overrides.parentObject,
+  };
+}
+
+describe('Agent7 - ConnectionManager', () => {
+  let manager: ConnectionManager;
+
+  beforeEach(() => {
+    manager = ConnectionManager.getInstance();
+    manager.clear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('creates unique connection point IDs for sequential additions', () => {
+    const first = manager.addConnectionPoint(
+      createConfig({ position: { x: 1, y: 0, z: 0 } })
+    );
+    const second = manager.addConnectionPoint(
+      createConfig({ position: { x: 2, y: 0, z: 0 } })
+    );
+
+    expect(first.getId()).not.toBe(second.getId());
+    expect(manager.getConnectionPointCount()).toBe(2);
+  });
+
+  it('prevents duplicate connectors within default tolerance', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const original = manager.addConnectionPoint(
+      createConfig({ position: { x: 5, y: 0, z: 0 } })
+    );
+    const duplicate = manager.addConnectionPoint(
+      createConfig({ position: { x: 5.005, y: 0, z: 0 } })
+    );
+
+    expect(duplicate.getId()).toBe(original.getId());
+    expect(manager.getConnectionPointCount()).toBe(1);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('finds duplicates only for matching types within tolerance', () => {
+    const pipe = manager.addConnectionPoint(
+      createConfig({ position: { x: -2, y: 1, z: 0 }, type: 'pipe' })
+    );
+
+    const sameTypeId = manager.findDuplicateAt(
+      { x: -2.005, y: 1.002, z: 0.004 },
+      'pipe',
+      0.01
+    );
+    const farAwayId = manager.findDuplicateAt(
+      { x: -2.2, y: 1.5, z: 0.2 },
+      'pipe',
+      0.01
+    );
+    const differentTypeId = manager.findDuplicateAt(
+      pipe.getPosition(),
+      'electrical',
+      0.01
+    );
+
+    expect(sameTypeId).toBe(pipe.getId());
+    expect(farAwayId).toBeNull();
+    expect(differentTypeId).toBeNull();
+  });
+
+  it('removing a connector cleans up connections on linked nodes', () => {
+    const source = manager.addConnectionPoint(
+      createConfig({ position: { x: 0, y: 0, z: 0 } })
+    );
+    const target = manager.addConnectionPoint(
+      createConfig({ position: { x: 0, y: 3, z: 0 } })
+    );
+
+    const connection = manager.createConnection(source.getId(), target.getId());
+    expect(connection).not.toBeNull();
+    expect(manager.getConnections(source.getId())).toHaveLength(1);
+    expect(manager.getConnections(target.getId())).toHaveLength(1);
+
+    const removed = manager.removeConnectionPoint(source.getId());
+    expect(removed).toBe(true);
+    expect(manager.getConnectionPoint(source.getId())).toBeNull();
+    expect(manager.getConnections(target.getId())).toHaveLength(0);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -18,10 +18,14 @@ export default defineConfig({
         '**/*.config.*',
         '**/mockData/',
         'dist/',
+        'tests/',
       ],
       include: ['src/**/*.{ts,tsx}'],
     },
-    include: ['src/**/*.{test,spec}.{ts,tsx}'],
+    include: [
+      'src/**/*.{test,spec}.{ts,tsx}',
+      'tests/**/*.{test,spec}.{ts,tsx}',
+    ],
     exclude: ['node_modules', 'dist', '.idea', '.git', '.cache'],
   },
   resolve: {


### PR DESCRIPTION
## Summary
- add tolerance-based duplicate detection inside `ConnectionManager` and reuse existing connectors when matched
- expose a `findDuplicateAt` helper so UI workflows can probe for existing points before creating new ones
- add Agent 7 regression tests for connector uniqueness and clean up plus allow Vitest to discover `tests/` suites
- log the daily standup entry for Agent 7 on the TODO board

## Testing
- `npx vitest run tests/routing/Agent7-Connections.test.ts`
- `npm run type-check` *(fails: existing JSX syntax errors in src/routing/ui/RoutingControlPanel.tsx)*
- `npm run lint` *(fails: existing lint violations across kinematics, library, and supabase modules)*

------
https://chatgpt.com/codex/tasks/task_e_69085dafe2dc8331aa258abab6592a47