### PR TITLE
[Agent 9] docs: add onboarding standup entry

### DIFF
--- a/docs/SMART_ROUTING/TODO_BOARD.md
+++ b/docs/SMART_ROUTING/TODO_BOARD.md
@@ -35,6 +35,14 @@
 
 ## 📅 Daily Standups
 
+### 2025-11-03 - Daily Updates
+
+#### Agent 9 - 2025-11-03
+- **Yesterday:** N/A (Starting today)
+- **Today:** Reading docs, setting up branch, starting WorldSerializer routing extensions review
+- **Blockers:** None
+- **PRs:** None yet
+
 ### 2025-01-03 - Kickoff Day
 
 #### Agent 1 - Graph & Pathfinding


### PR DESCRIPTION
## Summary
- add the 2025-11-03 daily standup entry for Agent 9 in the Smart Routing TODO board

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_69085dc880cc833192b0256da38102fd