### PR TITLE
[Agent 8] feat: add routing persistence serialization and exporters

### DIFF
--- a/docs/SMART_ROUTING/TODO_BOARD.md
+++ b/docs/SMART_ROUTING/TODO_BOARD.md
@@ -107,6 +107,15 @@
 - **Blockers:** None
 - **PRs:** None yet
 
+### 2025-01-04 - Daily Updates
+
+#### Agent 8 - 2025-01-04
+- **Yesterday:** N/A (Starting today)
+- **Today:** Implementing routing persistence serialization and export scaffolding
+- **Tomorrow:** Expand round-trip tests for routing persistence and BOM exporter coverage
+- **Blockers:** None
+- **PRs:** None yet
+
 ---
 
 ## 🎯 Phase 0 - Enablement (Day 0-1)

--- a/src/__tests__/smart-routing/exports/BOMExporter.test.ts
+++ b/src/__tests__/smart-routing/exports/BOMExporter.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from 'vitest';
+import { BOMExporter } from '../../../exports/BOMExporter';
+import { ConnectionPoint } from '../../../routing/core/ConnectionPoint';
+import { Route } from '../../../routing/core/Route';
+import type { ConnectionPointConfig, RouteSegment, SupportPoint } from '../../../routing/core/types';
+
+function createConnectionPointConfig(overrides: Partial<ConnectionPointConfig>): ConnectionPointConfig {
+  return {
+    type: 'pipe',
+    position: { x: 0, y: 0, z: 0 },
+    direction: { x: 0, y: 0, z: 1 },
+    specifications: { size: '3/4"', material: 'Steel' },
+    ...overrides,
+  };
+}
+
+describe('BOMExporter', () => {
+  it('creates CSV output with totals for routes', () => {
+    const source = new ConnectionPoint(createConnectionPointConfig({ position: { x: 0, y: 0, z: 0 } }));
+    const destination = new ConnectionPoint(createConnectionPointConfig({ position: { x: 1.5, y: 0, z: 0 } }));
+
+    const segments: RouteSegment[] = [
+      {
+        id: 'seg-1',
+        startPoint: source.getPosition(),
+        endPoint: { x: 1, y: 0, z: 0 },
+        segmentType: 'straight',
+        length: 1,
+      },
+      {
+        id: 'seg-2',
+        startPoint: { x: 1, y: 0, z: 0 },
+        endPoint: destination.getPosition(),
+        segmentType: 'bend',
+        bendRadius: 0.1,
+        length: 0.5,
+      },
+    ];
+
+    const supports: SupportPoint[] = [
+      {
+        id: 'sup-1',
+        position: { x: 0.5, y: 0, z: 0 },
+        type: 'hanger',
+        specification: 'Clamp',
+      },
+      {
+        id: 'sup-2',
+        position: { x: 1.2, y: 0, z: 0 },
+        type: 'hanger',
+        specification: 'Clamp',
+      },
+    ];
+
+    const route = new Route(
+      source,
+      destination,
+      segments,
+      { name: 'Steel', properties: {} },
+      {
+        minBendRadius: 0.25,
+        supportSpacing: 3,
+        clearance: { walls: 0.1, ceiling: 0.2, floor: 0.1, otherInfrastructure: 0.2 },
+      }
+    );
+    supports.forEach((support) => route.addSupport(support));
+
+    const exporter = new BOMExporter();
+    const csv = exporter.exportCSV([route]);
+    const lines = csv.split('\n');
+
+    expect(lines[0]).toBe('Route Type,Size,Material,Length (ft),Elbows,Tees,Reducers,Supports,Estimated Cost');
+
+    const dataRow = lines[1].split(',');
+    expect(dataRow[0]).toBe('pipe');
+    expect(dataRow[1]).toBe('3/4"');
+    expect(dataRow[2]).toBe('Steel');
+    expect(dataRow[3]).toBe('4.92');
+    expect(dataRow[4]).toBe('1');
+    expect(dataRow[7]).toBe('2');
+    expect(dataRow[8]).toBe('$138.58');
+
+    const totalsRow = lines[2].split(',');
+    expect(totalsRow[0]).toBe('TOTALS');
+    expect(totalsRow[3]).toBe('4.92');
+    expect(totalsRow[4]).toBe('1');
+    expect(totalsRow[7]).toBe('2');
+    expect(totalsRow[8]).toBe('$138.58');
+  });
+
+  it('returns header and zero totals when no routes are provided', () => {
+    const exporter = new BOMExporter();
+    const csv = exporter.exportCSV([]);
+    expect(csv).toBe('Route Type,Size,Material,Length (ft),Elbows,Tees,Reducers,Supports,Estimated Cost\nTOTALS,,,0.00,0,0,0,0,$0.00');
+  });
+});

--- a/src/__tests__/smart-routing/exports/GLBExporter.test.ts
+++ b/src/__tests__/smart-routing/exports/GLBExporter.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import type { Scene } from '@babylonjs/core';
+
+vi.mock('@babylonjs/serializers/glTF/2.0/glTFExporter', () => {
+  return {
+    GLTF2Export: {
+      GLBAsync: vi.fn(async () => ({
+        glTFFiles: {
+          'custom.glb': new Blob(['custom']),
+          'scene.glb': new Blob(['fallback']),
+        },
+      })),
+    },
+  };
+});
+
+import { GLTF2Export } from '@babylonjs/serializers/glTF/2.0/glTFExporter';
+import { GLBExporter } from '../../../exports/GLBExporter';
+
+const mockedGLBAsync = GLTF2Export.GLBAsync as unknown as ReturnType<typeof vi.fn>;
+
+describe('GLBExporter', () => {
+  beforeEach(() => {
+    mockedGLBAsync.mockClear();
+  });
+
+  it('captures material metadata and environment reference', async () => {
+    const fakeScene = {
+      materials: [
+        {
+          name: 'Steel',
+          uniqueId: 101,
+          getClassName: () => 'StandardMaterial',
+          diffuseColor: { r: 0.6, g: 0.6, b: 0.6 },
+          alpha: 0.9,
+          metadata: { textureUrl: 'steel-albedo.jpg' },
+        },
+      ],
+      environmentTexture: { name: 'studio.env' },
+    } as unknown as Scene;
+
+    const result = await GLBExporter.export(fakeScene, { fileName: 'custom', includeEnvironment: true });
+
+    expect(mockedGLBAsync).toHaveBeenCalledWith(fakeScene, 'custom', expect.objectContaining({ shouldExportNode: expect.any(Function) }));
+    expect(result.glb).toBeInstanceOf(Blob);
+    expect(result.metadata?.version).toBe('1.0.0');
+    expect(result.metadata?.materials).toHaveLength(1);
+    expect(result.metadata?.materials[0]).toMatchObject({
+      name: 'Steel',
+      properties: expect.objectContaining({
+        diffuseColor: { r: 0.6, g: 0.6, b: 0.6 },
+        alpha: 0.9,
+        textureUrl: 'steel-albedo.jpg',
+      }),
+    });
+    expect(result.metadata?.environmentTexture).toBe('studio.env');
+  });
+
+  it('omits metadata when disabled', async () => {
+    const fakeScene = { materials: [], environmentTexture: null } as unknown as Scene;
+
+    const result = await GLBExporter.export(fakeScene, { embedMaterialMetadata: false });
+
+    expect(result.metadata).toBeUndefined();
+  });
+});

--- a/src/__tests__/smart-routing/persistence/WorldSerializer.test.ts
+++ b/src/__tests__/smart-routing/persistence/WorldSerializer.test.ts
@@ -1,0 +1,143 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { ConnectionManager } from '../../../routing/core/ConnectionManager';
+import { Route } from '../../../routing/core/Route';
+import { useRoutingStore } from '../../../ui/store/routingStore';
+import {
+  restoreRoutingState,
+  serializeRoutingState,
+  serializeWorldMetadata,
+  type SerializedRoutingState,
+} from '../../../scene/WorldSerializer';
+import type { ConnectionPointConfig, RouteSegment, SupportPoint } from '../../../routing/core/types';
+
+function resetRoutingState(): void {
+  const store = useRoutingStore.getState();
+  store.clearConnectionPoints();
+  store.clearRoutes();
+  store.clearSelection();
+  store.clearValidationResults();
+  store.setRoutingMode('off');
+  store.setCurrentRouteType('pipe');
+  store.setOptimizationMode('shortest');
+  store.setPreviewRoute(null);
+  store.selectRoute(null);
+}
+
+function addConnectionPoint(config: Partial<ConnectionPointConfig> = {}) {
+  const connectionManager = ConnectionManager.getInstance();
+  const point = connectionManager.addConnectionPoint({
+    type: 'pipe',
+    position: { x: 0, y: 0, z: 0 },
+    direction: { x: 0, y: 0, z: 1 },
+    specifications: { size: '2"', material: 'Steel' },
+    ...config,
+  });
+  useRoutingStore.getState().addConnectionPoint(point);
+  return point;
+}
+
+describe('WorldSerializer routing integration', () => {
+  beforeEach(() => {
+    ConnectionManager.getInstance().clear();
+    resetRoutingState();
+  });
+
+  it('includes routing data when serializing world metadata', () => {
+    const source = addConnectionPoint();
+    const destination = addConnectionPoint({ position: { x: 1, y: 0, z: 0 } });
+
+    const segments: RouteSegment[] = [
+      {
+        id: 'seg-1',
+        startPoint: source.getPosition(),
+        endPoint: destination.getPosition(),
+        segmentType: 'straight',
+        length: 1,
+      },
+    ];
+
+    const supports: SupportPoint[] = [
+      {
+        id: 'sup-1',
+        position: { x: 0.5, y: 0, z: 0 },
+        type: 'hanger',
+        specification: 'Clamp',
+      },
+    ];
+
+    const route = new Route(
+      source,
+      destination,
+      segments,
+      { name: 'Steel', properties: {} },
+      {
+        minBendRadius: 0.25,
+        supportSpacing: 3,
+        clearance: { walls: 0.1, ceiling: 0.2, floor: 0.1, otherInfrastructure: 0.2 },
+      }
+    );
+    supports.forEach((support) => route.addSupport(support));
+    useRoutingStore.getState().addRoute(route);
+    ConnectionManager.getInstance().createConnection(source.getId(), destination.getId(), route.getId());
+
+    const metadata = serializeWorldMetadata();
+
+    expect(metadata.routing).toBeDefined();
+    expect(metadata.routing?.connectors).toHaveLength(2);
+    expect(metadata.routing?.routes).toHaveLength(1);
+    const serializedRoute = metadata.routing?.routes[0];
+    expect(serializedRoute?.sourceId).toBe(source.getId());
+    expect(serializedRoute?.destinationId).toBe(destination.getId());
+  });
+
+  it('restores routing state from serialized snapshot', () => {
+    const source = addConnectionPoint();
+    const destination = addConnectionPoint({ position: { x: 2, y: 0, z: 0 } });
+
+    const segments: RouteSegment[] = [
+      {
+        id: 'seg-1',
+        startPoint: source.getPosition(),
+        endPoint: destination.getPosition(),
+        segmentType: 'straight',
+        length: 2,
+      },
+      {
+        id: 'seg-2',
+        startPoint: destination.getPosition(),
+        endPoint: { x: 2, y: 1, z: 0 },
+        segmentType: 'bend',
+        length: 1,
+      },
+    ];
+
+    const route = new Route(
+      source,
+      destination,
+      segments,
+      { name: 'Steel', properties: {} },
+      {
+        minBendRadius: 0.25,
+        supportSpacing: 3,
+        clearance: { walls: 0.1, ceiling: 0.2, floor: 0.1, otherInfrastructure: 0.2 },
+      }
+    );
+    useRoutingStore.getState().addRoute(route);
+    ConnectionManager.getInstance().createConnection(source.getId(), destination.getId(), route.getId());
+
+    const snapshot = serializeRoutingState() as SerializedRoutingState;
+    expect(snapshot).toBeDefined();
+
+    ConnectionManager.getInstance().clear();
+    resetRoutingState();
+
+    restoreRoutingState(snapshot);
+
+    const store = useRoutingStore.getState();
+    expect(store.connectionPoints).toHaveLength(2);
+    expect(store.activeRoutes).toHaveLength(1);
+    const restoredRoute = store.activeRoutes[0];
+    expect(restoredRoute.segments).toHaveLength(2);
+    expect(restoredRoute.type).toBe('pipe');
+  });
+});

--- a/src/exports/BOMExporter.ts
+++ b/src/exports/BOMExporter.ts
@@ -1,0 +1,132 @@
+import type { Route as RouteModel, RouteType } from '../routing/core/types';
+
+const METERS_TO_FEET = 3.28084;
+
+interface BomLine {
+  routeType: RouteType;
+  size: string;
+  material: string;
+  lengthFeet: number;
+  elbows: number;
+  tees: number;
+  reducers: number;
+  supports: number;
+  estimatedCost: number;
+}
+
+const COST_FACTORS: Record<RouteType, { perFoot: number; elbow: number; tee: number; reducer: number; support: number }> = {
+  pipe: { perFoot: 18, elbow: 22, tee: 48, reducer: 35, support: 14 },
+  electrical: { perFoot: 9, elbow: 12, tee: 16, reducer: 0, support: 8 },
+  cable_tray: { perFoot: 21, elbow: 26, tee: 30, reducer: 0, support: 18 },
+  conduit: { perFoot: 7, elbow: 10, tee: 12, reducer: 0, support: 6 },
+};
+
+function formatNumber(value: number): string {
+  return value.toFixed(2);
+}
+
+function formatCurrency(value: number): string {
+  return `$${value.toFixed(2)}`;
+}
+
+function sumLengths(route: RouteModel): number {
+  return route.segments.reduce((total, segment) => total + (segment.length ?? 0), 0);
+}
+
+function resolveSize(route: RouteModel): string {
+  return (
+    route.source.specifications.size ||
+    route.destination.specifications.size ||
+    route.source.specifications.material ||
+    route.destination.specifications.material ||
+    'N/A'
+  );
+}
+
+function resolveMaterial(route: RouteModel): string {
+  return route.material?.name ?? route.source.specifications.material ?? route.destination.specifications.material ?? 'Unknown';
+}
+
+function buildBomLine(route: RouteModel): BomLine {
+  const lengthMeters = sumLengths(route);
+  const lengthFeet = lengthMeters * METERS_TO_FEET;
+  const elbows = route.segments.filter((segment) => segment.segmentType === 'bend').length;
+  const tees = route.segments.filter((segment) => segment.segmentType === 'fitting').length;
+  const reducers = 0;
+  const supports = route.supports.length;
+
+  const costFactors = COST_FACTORS[route.type];
+  const estimatedCost =
+    lengthFeet * costFactors.perFoot +
+    elbows * costFactors.elbow +
+    tees * costFactors.tee +
+    reducers * costFactors.reducer +
+    supports * costFactors.support;
+
+  return {
+    routeType: route.type,
+    size: resolveSize(route),
+    material: resolveMaterial(route),
+    lengthFeet,
+    elbows,
+    tees,
+    reducers,
+    supports,
+    estimatedCost,
+  };
+}
+
+function serializeLine(line: BomLine): string {
+  return [
+    line.routeType.replace('_', ' '),
+    line.size,
+    line.material,
+    formatNumber(line.lengthFeet),
+    line.elbows,
+    line.tees,
+    line.reducers,
+    line.supports,
+    formatCurrency(line.estimatedCost),
+  ].join(',');
+}
+
+export class BOMExporter {
+  exportCSV(routes: RouteModel[]): string {
+    const header = 'Route Type,Size,Material,Length (ft),Elbows,Tees,Reducers,Supports,Estimated Cost';
+    if (routes.length === 0) {
+      return `${header}\nTOTALS,,,0.00,0,0,0,0,$0.00`;
+    }
+
+    const lines = routes.map((route) => buildBomLine(route));
+
+    const totals = lines.reduce(
+      (acc, line) => {
+        acc.lengthFeet += line.lengthFeet;
+        acc.elbows += line.elbows;
+        acc.tees += line.tees;
+        acc.reducers += line.reducers;
+        acc.supports += line.supports;
+        acc.estimatedCost += line.estimatedCost;
+        return acc;
+      },
+      { lengthFeet: 0, elbows: 0, tees: 0, reducers: 0, supports: 0, estimatedCost: 0 }
+    );
+
+    const body = lines.map(serializeLine).join('\n');
+    const totalsRow = [
+      'TOTALS',
+      '',
+      '',
+      formatNumber(totals.lengthFeet),
+      totals.elbows,
+      totals.tees,
+      totals.reducers,
+      totals.supports,
+      formatCurrency(totals.estimatedCost),
+    ].join(',');
+
+    return [header, body, totalsRow].join('\n');
+  }
+}
+
+export default BOMExporter;

--- a/src/exports/GLBExporter.ts
+++ b/src/exports/GLBExporter.ts
@@ -1,0 +1,121 @@
+import * as BABYLON from '@babylonjs/core';
+import { GLTF2Export } from '@babylonjs/serializers/glTF/2.0/glTFExporter';
+
+export interface MaterialExportMetadata {
+  id: string;
+  name: string;
+  type: string;
+  properties: Record<string, unknown>;
+}
+
+export interface GLBExportMetadata {
+  version: string;
+  materials: MaterialExportMetadata[];
+  environmentTexture?: string | null;
+}
+
+export interface GLBExportOptions {
+  fileName?: string;
+  includeEnvironment?: boolean;
+  embedMaterialMetadata?: boolean;
+}
+
+export interface GLBExportResult {
+  glb: Blob;
+  metadata?: GLBExportMetadata;
+}
+
+function pickMaterialProperties(material: BABYLON.Material): Record<string, unknown> {
+  const props: Record<string, unknown> = {};
+  const anyMaterial = material as any;
+
+  if (anyMaterial.diffuseColor) {
+    props.diffuseColor = {
+      r: anyMaterial.diffuseColor.r,
+      g: anyMaterial.diffuseColor.g,
+      b: anyMaterial.diffuseColor.b,
+    };
+  }
+
+  if (anyMaterial.albedoColor) {
+    props.albedoColor = {
+      r: anyMaterial.albedoColor.r,
+      g: anyMaterial.albedoColor.g,
+      b: anyMaterial.albedoColor.b,
+    };
+  }
+
+  if (typeof anyMaterial.alpha === 'number') {
+    props.alpha = anyMaterial.alpha;
+  }
+
+  if (typeof anyMaterial.metallic === 'number') {
+    props.metallic = anyMaterial.metallic;
+  }
+
+  if (typeof anyMaterial.roughness === 'number') {
+    props.roughness = anyMaterial.roughness;
+  }
+
+  if (anyMaterial.diffuseTexture?.name) {
+    props.diffuseTexture = anyMaterial.diffuseTexture.name;
+  }
+
+  if (anyMaterial.environmentTexture?.name) {
+    props.environmentTexture = anyMaterial.environmentTexture.name;
+  }
+
+  if (material.metadata?.textureUrl) {
+    props.textureUrl = material.metadata.textureUrl;
+  }
+
+  return props;
+}
+
+export class GLBExporter {
+  static collectMaterialMetadata(scene: BABYLON.Scene): MaterialExportMetadata[] {
+    return (scene.materials ?? []).map((material) => ({
+      id: material.uniqueId?.toString() ?? material.name,
+      name: material.name,
+      type: typeof material.getClassName === 'function' ? material.getClassName() : 'Material',
+      properties: pickMaterialProperties(material),
+    }));
+  }
+
+  static getEnvironmentReference(scene: BABYLON.Scene): string | null {
+    const environment = scene.environmentTexture as any;
+    if (!environment) {
+      return null;
+    }
+
+    return environment.name ?? environment.metadata?.url ?? null;
+  }
+
+  static async export(scene: BABYLON.Scene, options: GLBExportOptions = {}): Promise<GLBExportResult> {
+    const { fileName = 'scene', includeEnvironment = true, embedMaterialMetadata = true } = options;
+
+    const exportData = await GLTF2Export.GLBAsync(scene, fileName, {
+      shouldExportNode: (node) => !(node.metadata?.skipExport),
+    });
+
+    const glbKey = `${fileName}.glb`;
+    const glbBlob = (exportData.glTFFiles[glbKey] ?? exportData.glTFFiles['scene.glb']) as Blob | undefined;
+
+    if (!glbBlob) {
+      throw new Error('GLB export did not produce a binary payload');
+    }
+
+    let metadata: GLBExportMetadata | undefined;
+    if (embedMaterialMetadata) {
+      metadata = {
+        version: '1.0.0',
+        materials: GLBExporter.collectMaterialMetadata(scene),
+        environmentTexture: includeEnvironment ? GLBExporter.getEnvironmentReference(scene) : null,
+      };
+    }
+
+    return { glb: glbBlob, metadata };
+  }
+}
+
+export default GLBExporter;

--- a/src/scene/WorldSerializer.ts
+++ b/src/scene/WorldSerializer.ts
@@ -7,9 +7,19 @@ import { SceneTreeManager } from './SceneTreeManager';
 import { SceneManager } from './SceneManager';
 import { EntityRegistry } from '../entities/EntityRegistry';
 import { userToBabylon } from '../core/CoordinateSystem';
-import { AssetReference } from '../core/types';
+import { AssetReference, Vector3 } from '../core/types';
 import { toast } from '../ui/components/ToastNotifications';
 import type { SceneNode } from './SceneTreeNode';
+import { ConnectionManager } from '../routing/core/ConnectionManager';
+import { useRoutingStore } from '../ui/store/routingStore';
+import { Route } from '../routing/core/Route';
+import type {
+  ConnectionSpecifications,
+  Route as RouteModel,
+  RouteConstraints,
+  RouteSegment,
+  SupportPoint,
+} from '../routing/core/types';
 
 export interface WorldData {
   version: string;
@@ -17,6 +27,7 @@ export interface WorldData {
   tree: {
     nodes: Array<SceneNode>;
   };
+  routing?: SerializedRoutingState;
 }
 
 export interface BabylonWorldData {
@@ -24,6 +35,62 @@ export interface BabylonWorldData {
   timestamp: number;
   babylonScene: any; // Babylon scene serialization
   metadata: WorldData; // kinetiCORE metadata
+}
+
+export type SerializedVector3 = [number, number, number];
+
+export interface SerializedConnector {
+  id: string;
+  type: RouteModel['type'];
+  position: SerializedVector3;
+  direction: SerializedVector3;
+  specifications: ConnectionSpecifications;
+  parentObject?: string;
+}
+
+export interface SerializedSegment {
+  id: string;
+  startPoint: SerializedVector3;
+  endPoint: SerializedVector3;
+  segmentType: RouteSegment['segmentType'];
+  bendRadius?: number;
+  length: number;
+}
+
+export interface SerializedSupport {
+  id: string;
+  position: SerializedVector3;
+  type: SupportPoint['type'];
+  specification: string;
+}
+
+export interface SerializedRoute {
+  id: string;
+  type: RouteModel['type'];
+  sourceId: string;
+  destinationId: string;
+  segments: SerializedSegment[];
+  supports: SerializedSupport[];
+  material: RouteModel['material'];
+  constraints: RouteConstraints;
+  generated: boolean;
+}
+
+export interface SerializedRoutingState {
+  version: string;
+  connectors: SerializedConnector[];
+  routes: SerializedRoute[];
+}
+
+const ROUTING_SERIALIZATION_VERSION = '1.0.0';
+
+function vector3ToSerialized(vector: Vector3): SerializedVector3 {
+  return [vector.x, vector.y, vector.z];
+}
+
+function serializedToVector3(tuple: SerializedVector3): Vector3 {
+  const [x, y, z] = tuple;
+  return { x, y, z };
 }
 
 export interface JointData {
@@ -57,12 +124,15 @@ export interface ComprehensiveWorldData {
   version: string;
   timestamp: number;
   format: 'comprehensive';
-  
+
   // Scene structure
   tree: {
     nodes: Array<SceneNode>;
   };
-  
+
+  // Routing system state
+  routing?: SerializedRoutingState;
+
   // Babylon.js scene data
   babylonScene: any;
   
@@ -153,12 +223,38 @@ export function validateWorldData(worldData: ComprehensiveWorldData): { isValid:
         }
       }
     }
-    
+
     if (worldData.assets.materials) {
       for (const material of worldData.assets.materials) {
         if (!material.id || !material.name || !material.type) {
           errors.push('Invalid material data');
         }
+      }
+    }
+  }
+
+  if (worldData.routing) {
+    const connectorIds = new Set<string>();
+    for (const connector of worldData.routing.connectors) {
+      if (!connector.id) {
+        errors.push('Routing connector missing ID');
+        continue;
+      }
+      if (connectorIds.has(connector.id)) {
+        errors.push(`Duplicate routing connector ID: ${connector.id}`);
+      }
+      connectorIds.add(connector.id);
+    }
+
+    for (const route of worldData.routing.routes) {
+      if (!route.id) {
+        errors.push('Routing route missing ID');
+      }
+      if (route.sourceId && !connectorIds.has(route.sourceId)) {
+        errors.push(`Route ${route.id} references unknown source connector ${route.sourceId}`);
+      }
+      if (route.destinationId && !connectorIds.has(route.destinationId)) {
+        errors.push(`Route ${route.id} references unknown destination connector ${route.destinationId}`);
       }
     }
   }
@@ -268,11 +364,163 @@ export interface KinematicChainData {
 }
 
 /**
+ * Serialize routing system state (connection points and routes)
+ */
+export function serializeRoutingState(): SerializedRoutingState | undefined {
+  const connectionManager = ConnectionManager.getInstance();
+  const connectors = connectionManager.getAllConnectionPoints();
+  const routes = useRoutingStore.getState().activeRoutes;
+
+  if (connectors.length === 0 && routes.length === 0) {
+    return undefined;
+  }
+
+  const serializedConnectors: SerializedConnector[] = connectors.map((connector) => ({
+    id: connector.getId(),
+    type: connector.getType(),
+    position: vector3ToSerialized(connector.getPosition()),
+    direction: vector3ToSerialized(connector.getDirection()),
+    specifications: { ...connector.specifications },
+    parentObject: connector.parentObject,
+  }));
+
+  const serializedRoutes: SerializedRoute[] = routes.map((route) => ({
+    id: route.getId(),
+    type: route.type,
+    sourceId: route.source.getId(),
+    destinationId: route.destination.getId(),
+    segments: route.segments.map((segment) => ({
+      id: segment.id,
+      startPoint: vector3ToSerialized(segment.startPoint),
+      endPoint: vector3ToSerialized(segment.endPoint),
+      segmentType: segment.segmentType,
+      bendRadius: segment.bendRadius,
+      length: segment.length,
+    })),
+    supports: route.supports.map((support) => ({
+      id: support.id,
+      position: vector3ToSerialized(support.position),
+      type: support.type,
+      specification: support.specification,
+    })),
+    material: {
+      ...route.material,
+      properties: route.material.properties ? { ...route.material.properties } : undefined,
+    },
+    constraints: JSON.parse(JSON.stringify(route.constraints)) as RouteConstraints,
+    generated: route.generated,
+  }));
+
+  return {
+    version: ROUTING_SERIALIZATION_VERSION,
+    connectors: serializedConnectors,
+    routes: serializedRoutes,
+  };
+}
+
+/**
+ * Restore routing state from serialized data
+ */
+export function restoreRoutingState(routing?: SerializedRoutingState | null): void {
+  const connectionManager = ConnectionManager.getInstance();
+  const routingStore = useRoutingStore.getState();
+  const registry = EntityRegistry.getInstance();
+
+  // Clear existing routing data
+  connectionManager.clear();
+  routingStore.clearConnectionPoints();
+  routingStore.clearRoutes();
+  routingStore.clearValidationResults();
+  routingStore.clearSelection();
+  routingStore.selectRoute(null);
+  routingStore.setPreviewRoute(null);
+  routingStore.setRoutingMode('off');
+
+  if (!routing || routing.connectors.length === 0) {
+    return;
+  }
+
+  const connectorMap = new Map<string, ReturnType<typeof connectionManager.addConnectionPoint>>();
+
+  for (const connector of routing.connectors) {
+    const config = {
+      type: connector.type,
+      position: serializedToVector3(connector.position),
+      direction: serializedToVector3(connector.direction),
+      specifications: { ...connector.specifications } as ConnectionSpecifications,
+      parentObject: connector.parentObject,
+    };
+
+    const point = connectionManager.addConnectionPoint(config);
+    connectorMap.set(connector.id, point);
+
+    if (connector.parentObject) {
+      const entity = registry.get(connector.parentObject);
+      entity?.addConnectionPointId(point.getId());
+    }
+
+    routingStore.addConnectionPoint(point);
+  }
+
+  for (const serializedRoute of routing.routes) {
+    const source = connectorMap.get(serializedRoute.sourceId);
+    const destination = connectorMap.get(serializedRoute.destinationId);
+
+    if (!source || !destination) {
+      console.warn(`Skipping route ${serializedRoute.id} - missing connectors`);
+      continue;
+    }
+
+    const segments: RouteSegment[] = serializedRoute.segments.map((segment) => ({
+      id: segment.id,
+      startPoint: serializedToVector3(segment.startPoint),
+      endPoint: serializedToVector3(segment.endPoint),
+      segmentType: segment.segmentType,
+      bendRadius: segment.bendRadius,
+      length: segment.length,
+    }));
+
+    const supports: SupportPoint[] = serializedRoute.supports.map((support) => ({
+      id: support.id,
+      position: serializedToVector3(support.position),
+      type: support.type,
+      specification: support.specification,
+    }));
+
+    const material = {
+      ...serializedRoute.material,
+      properties: serializedRoute.material?.properties
+        ? { ...serializedRoute.material.properties }
+        : undefined,
+    } as RouteModel['material'];
+
+    const constraints = JSON.parse(JSON.stringify(serializedRoute.constraints)) as RouteConstraints;
+
+    const route = Route.createWithType(
+      serializedRoute.id,
+      source,
+      destination,
+      serializedRoute.type,
+      segments,
+      supports,
+      material,
+      constraints
+    );
+    route.generated = serializedRoute.generated;
+
+    routingStore.addRoute(route);
+    connectionManager.createConnection(source.getId(), destination.getId(), route.getId());
+  }
+}
+
+/**
  * Serialize the entire world state to JSON (legacy - metadata only)
  */
 export function serializeWorld(): string {
   const tree = SceneTreeManager.getInstance();
   const allNodes = tree.getAllNodes();
+
+  const routing = serializeRoutingState();
 
   const worldData: WorldData = {
     version: '1.0.0',
@@ -280,6 +528,7 @@ export function serializeWorld(): string {
     tree: {
       nodes: allNodes,
     },
+    routing,
   };
 
   return JSON.stringify(worldData, null, 2);
@@ -314,6 +563,7 @@ export async function serializeComprehensiveWorld(): Promise<string> {
 
   // Collect kinematics data
   const kinematics = await collectKinematicsData(scene, tree);
+  const routing = serializeRoutingState();
 
   // Create comprehensive world data
   const worldData: ComprehensiveWorldData = {
@@ -323,6 +573,7 @@ export async function serializeComprehensiveWorld(): Promise<string> {
     tree: {
       nodes: allNodes,
     },
+    routing,
     babylonScene,
     assets,
     physics,
@@ -1225,7 +1476,15 @@ export function restoreWorldState(worldData: WorldData, isComprehensive: boolean
     }
 
     console.log(`Restored world with ${worldData.tree.nodes.length} nodes`);
-    
+
+    // Restore routing state if available
+    if (worldData.routing) {
+      restoreRoutingState(worldData.routing);
+    } else {
+      // Ensure routing state is cleared if not provided
+      restoreRoutingState(undefined);
+    }
+
     // Notify UI components that the tree has been updated
     // Use setTimeout to ensure the event is dispatched after React has processed the tree changes
     console.log('🔄 Dispatching scenetree-update event to refresh UI...');
@@ -1393,6 +1652,7 @@ export function serializeBabylonWorld(): string {
 export function serializeWorldMetadata(): WorldData {
   const tree = SceneTreeManager.getInstance();
   const allNodes = tree.getAllNodes();
+  const routing = serializeRoutingState();
 
   return {
     version: '1.0.0',
@@ -1400,6 +1660,7 @@ export function serializeWorldMetadata(): WorldData {
     tree: {
       nodes: allNodes,
     },
+    routing,
   };
 }
 


### PR DESCRIPTION
## Summary
- extend the world serializer to capture routing connectors and routes within both metadata and comprehensive saves, and restore them on load
- add BOMExporter and GLBExporter utilities for routing outputs with corresponding unit coverage
- record the Agent 8 daily standup entry in the TODO board

## Testing
- npx vitest run src/__tests__/smart-routing/exports/BOMExporter.test.ts src/__tests__/smart-routing/exports/GLBExporter.test.ts src/__tests__/smart-routing/persistence/WorldSerializer.test.ts

------
https://chatgpt.com/codex/tasks/task_e_69085dbbdf308331910aa79f8206c086